### PR TITLE
Update Validator.ts

### DIFF
--- a/src/services/Validator.ts
+++ b/src/services/Validator.ts
@@ -31,7 +31,7 @@ export class Validator {
     );
     const migrationsDir = fs.readdirSync(migrationsDirPath);
 
-    return name !== "migration_lock.toml" && migrationsDir.includes(name);
+    return name !== "migration_lock.toml" && name !== ".DS_STORE" && migrationsDir.includes(name);
   }
 
   validateMigrationName(name: string) {


### PR DESCRIPTION
I added an extra check to ignore the .DS_STORE file for mac users, which is present by default for all developers using macos. (atm the script is crashing because we call `isMigrationWithPostScript` on a non folder.