### PR TITLE
docs: Update README with the database support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ The configuration file (`prisma-dm.config.json`) allows customization of the lib
 
 - **Database support**:
 
-  - Fully tested with PostgreSQL.
-  - Other databases may require additional logic; contributions are welcome.
+  - For now works only with PostgreSQL and PostgreSQL-compatible databases.
+  - Other databases will require additional logic; contributions are welcome.
 
 - **Future improvements**:
   - Plans to track post scripts in a dedicated database table to improve reliability. Community contributions are highly encouraged.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The configuration file (`prisma-dm.config.json`) allows customization of the lib
 
 - **Database support**:
 
-  - For now works only with PostgreSQL and PostgreSQL-compatible databases.
+  - Fully tested on PostgreSQL and for now will work only with PostgreSQL and PostgreSQL-compatible databases.
   - Other databases will require additional logic; contributions are welcome.
 
 - **Future improvements**:

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The configuration file (`prisma-dm.config.json`) allows customization of the lib
 
 - **Database support**:
 
-  - Fully tested on PostgreSQL and for now will work only with PostgreSQL and PostgreSQL-compatible databases.
+  - Fully tested with PostgreSQL and for now will only work with PostgreSQL and probably other PostgreSQL-compatible databases.
   - Other databases will require additional logic; contributions are welcome.
 
 - **Future improvements**:


### PR DESCRIPTION
Since the script uses `slonik` library to create the database client, it will only support PostgreSQL and probably other PostgreSQL-compatible databases.

No point in giving hope that it may work with other databases 😄 (found out the hard way with MSSQL)