### PR TITLE
Introduce --upto, optional config keys, custom migration schema name, .DS_Store typo fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .git
 node_modules
 dist
+.idea

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Commands:
    Place the `schema.prisma` file in the corresponding migration folder alongside `migration.sql`. This file must match the schema state after applying the Prisma migration.
 
    ⚠️ **Note**: You can skip copying the `schema.prisma` file and generating types if you do not need the Prisma Client. Instead, you can simply add the post-migration script directly to the migration folder.
+   ⚠️ **Note**: You can change the default `schema.prisma` filename by using the `migrationSchemaFileName` key in the config.
 
 4. **Generate Types**:
    Run the `generate` command to create TypeScript types for your data migrations based on your schemas:
@@ -130,11 +131,20 @@ Commands:
    ```bash
    npx prisma-dm migrate
    ```
+   (by default, it migrates to `latest`)
 
-   ⚠️ **Note**: You can use the `--to` flag to migrate to a specific migration version (by default, it migrates to `latest`). Example:
+   ⚠️ **Note**: You can use the `--to` flag to migrate to a specific migration version (not including the migration 
+   passed. Example:
 
    ```bash
    npx prisma-dm migrate --to 20250108201031_add_user_name
+   ```
+
+   ⚠️ **Note**: You can use the `--upto` flag to migrate to a specific migration version (including the one passed) (by
+   default, it migrates to `latest`). Example:
+
+   ```bash
+   npx prisma-dm migrate --upto 20250108201031_add_user_name
    ```
 
 ## Configuration
@@ -151,6 +161,9 @@ The configuration file (`prisma-dm.config.json`) allows customization of the lib
 - **`migrationsDir`**: Directory containing Prisma migrations. Default: `prisma/migrations`.
 
 - **`tempDir`**: Temporary directory for moving migration folders during execution. Default: `prisma/.temp`.
+- 
+- **`migrationSchemaFileName`**: The filename for prisma schema files within migration directories. Default: `schema.
+  prisma`.
 
 - **`log`**: Logging level (`none`, `info`, `verbose`). Default: `info`.
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -32,6 +32,12 @@
       "description": "Temporary directory for processing. Must be a valid directory path.",
       "default": "prisma/.temp"
     },
+    "migrationSchemaFileName": {
+      "type": "string",
+      "pattern": "^[^\\s]+\\.[^\\s]+$",
+      "description": "The filename for prisma schema files within migration directories. Defaults to schema.prisma",
+      "default": "schema.prisma"
+    },
     "log": {
       "type": "string",
       "enum": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.17.1",
-        "commander": "^13.0.0",
+        "commander": "^13.1.0",
         "dotenv": "^16.4.7",
         "fs-extra": "^11.2.0",
         "slonik": "^46.4.0"
@@ -211,9 +211,9 @@
       "dev": true
     },
     "node_modules/commander": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
-      "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "ajv": "^8.17.1",
-    "commander": "^13.0.0",
+    "commander": "^13.1.0",
     "dotenv": "^16.4.7",
     "fs-extra": "^11.2.0",
     "slonik": "^46.4.0"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -68,12 +68,16 @@ program
 program
   .command("migrate")
   .description("Migrate to target migration with post scripts execution")
-  .option("--to <value>", "Target migration", "latest")
+  .option("--to <value>", "Target migration")
+  .option("--upto <value>", "Target migration = Run all migrations up to (and including) this one")
   .action(async (options) => {
-    const toOption = options.to as string | undefined;
-    const to = toOption === "latest" ? undefined : toOption;
+    if(options.to && options.upto) {
+      throw new Error('options "to" and "upto" can not be used together');
+    }
+    const toOption: string | undefined = options.to ?? options.upto;
+    const targetMigration = toOption === "latest" ? undefined : toOption;
 
-    await createCLI().migrate({ to });
+    await createCLI().migrate({ targetMigration, includeTargetMigration: !options.to });
   });
 
 program.on("command:*", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { getConfig } from "./config/getConfig";
+import {configLoader} from "./config/getConfig";
 import { CLI } from "./services/CLI";
 import { Logger } from "./services/Logger";
 import { DB } from "./services/DB";
@@ -16,7 +16,7 @@ dotenv.config();
 const program = new Command();
 
 function createCLI() {
-  const config = getConfig();
+  const config = configLoader.getConfig();
   const logger = new Logger(config);
   const prisma = new DB();
   const validator = new Validator(config);

--- a/src/config/config.type.ts
+++ b/src/config/config.type.ts
@@ -27,6 +27,10 @@ export interface ConfigSchema {
    */
   tempDir: string;
   /**
+   * The filename for prisma schema files within migration directories.
+   */
+  migrationSchemaFileName: string;
+  /**
    * Log level for the script, must be one of 'info', 'debug', or 'error'.
    */
   log: "none" | "info" | "verbose";

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -4,12 +4,28 @@ import { ConfigSchema } from "./config.type";
 import { CONFIG_FILE_NAME } from "./CONFIG_FILE_NAME";
 import schema from "../../config.schema.json";
 import Ajv from "ajv";
+import {DEFAULT_CONFIG} from "./DEFAULT_CONFIG";
 
 export function getConfig(): ConfigSchema {
   try {
     const configFilePath = path.join(process.cwd(), CONFIG_FILE_NAME);
-    const file = fs.readFileSync(configFilePath, "utf-8");
-    const config = JSON.parse(file);
+    let parsedConfig = {};
+    try {
+      const file = fs.readFileSync(configFilePath, "utf-8");
+      parsedConfig = JSON.parse(file);
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        console.info(`No config file ${CONFIG_FILE_NAME} found, using defaults`)
+      }else {
+        throw new Error(
+          "Could not read config file"
+        );
+      }
+    }
+    const config: ConfigSchema = {
+      ...DEFAULT_CONFIG,
+      ...parsedConfig
+    };
 
     const ajv = new Ajv();
     const validate = ajv.compile(schema);
@@ -19,12 +35,10 @@ export function getConfig(): ConfigSchema {
       throw new Error("Configuration validation failed.");
     }
 
-    const typedConfig = config as ConfigSchema;
-
     return {
-      migrationsDir: path.join(process.cwd(), typedConfig.migrationsDir),
-      tempDir: path.join(process.cwd(), typedConfig.tempDir),
-      ...typedConfig,
+      migrationsDir: path.join(process.cwd(), config.migrationsDir),
+      tempDir: path.join(process.cwd(), config.tempDir),
+      ...config,
     };
   } catch (error) {
     if (error.code === "ENOENT") {

--- a/src/services/CLI.ts
+++ b/src/services/CLI.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import fs from "fs-extra";
 import { CONFIG_FILE_NAME } from "../config/CONFIG_FILE_NAME";
-import { getConfig } from "../config/getConfig";
+import {configLoader} from "../config/getConfig";
 import { DEFAULT_CONFIG } from "../config/DEFAULT_CONFIG";
 import { Validator } from "./Validator";
 import { PrismaCLI } from "../utils/classes/PrismaCLI";
@@ -32,7 +32,7 @@ export class CLI<T extends string> {
   }
 
   generate() {
-    const config = getConfig();
+    const config = configLoader.getConfig();
     const migrationsDirPath = path.join(process.cwd(), config.migrationsDir);
     const migrationsDir = fs.readdirSync(migrationsDirPath);
 
@@ -88,7 +88,7 @@ export class CLI<T extends string> {
       this.validator.validateMigrationName(targetMigration);
     }
 
-    const config = getConfig();
+    const config = configLoader.getConfig();
     const migrationsDirPath = path.join(process.cwd(), config.migrationsDir);
     const rawMigrations = fs
       .readdirSync(migrationsDirPath)

--- a/src/services/CLI.ts
+++ b/src/services/CLI.ts
@@ -39,7 +39,7 @@ export class CLI<T extends string> {
     for (const migrationName of migrationsDir) {
       if (this.validator.isMigrationWithPrismaSchema(migrationName)) {
         const migrationPath = path.join(migrationsDirPath, migrationName);
-        const schemaPath = path.join(migrationPath, "schema.prisma");
+        const schemaPath = path.join(migrationPath, config.migrationSchemaFileName);
         const outputPath = `${config.outputDir}/${migrationName}`;
 
         this.logger.logInfo(`Generating types for migration: ${migrationName}`);
@@ -83,9 +83,9 @@ export class CLI<T extends string> {
     this.logger.logInfo("Schema files merged");
   }
 
-  async migrate({ to }: { to?: T | undefined } = {}) {
-    if (to) {
-      this.validator.validateMigrationName(to);
+  async migrate({ targetMigration, includeTargetMigration }: { targetMigration?: T | undefined, includeTargetMigration: boolean }) {
+    if (targetMigration) {
+      this.validator.validateMigrationName(targetMigration);
     }
 
     const config = getConfig();
@@ -93,10 +93,11 @@ export class CLI<T extends string> {
     const rawMigrations = fs
       .readdirSync(migrationsDirPath)
       .filter((m) => this.validator.isMigration(m));
-    const lastMigrationIndex = to
-      ? rawMigrations.indexOf(to)
+    const lastMigrationIndex = targetMigration
+      ? rawMigrations.indexOf(targetMigration)
       : rawMigrations.length;
-    const migrations = rawMigrations.slice(0, lastMigrationIndex);
+
+    const migrations = rawMigrations.slice(0, lastMigrationIndex + (includeTargetMigration ? 1 : 0));
     const dataMigrations = migrations.filter((m) =>
       this.validator.isMigrationWithPostScript(m)
     );

--- a/src/services/TargetedPrismaMigrator.ts
+++ b/src/services/TargetedPrismaMigrator.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import fs from "fs-extra";
 import { ConfigSchema } from "../config/config.type";
-import { getConfig } from "../config/getConfig";
+import {configLoader} from "../config/getConfig";
 import { PrismaCLI } from "../utils/classes/PrismaCLI";
 import { Logger } from "./Logger";
 
@@ -11,7 +11,7 @@ export class TargetedPrismaMigrator<T extends string> {
   private readonly config: ConfigSchema;
 
   constructor(private readonly logger: Logger) {
-    this.config = getConfig();
+    this.config = configLoader.getConfig();
   }
 
   private createTempDir() {

--- a/src/services/Validator.ts
+++ b/src/services/Validator.ts
@@ -8,7 +8,7 @@ export class Validator {
   isMigrationWithPrismaSchema(migrationName: string) {
     const migrationPath = path.join(this.config.migrationsDir, migrationName);
     const hasPrismaSchema = fs.existsSync(
-      path.join(migrationPath, "schema.prisma")
+      path.join(migrationPath, this.config.migrationSchemaFileName)
     );
 
     return this.isMigration(migrationName) && hasPrismaSchema;
@@ -31,7 +31,7 @@ export class Validator {
     );
     const migrationsDir = fs.readdirSync(migrationsDirPath);
 
-    return name !== "migration_lock.toml" && name !== ".DS_STORE" && migrationsDir.includes(name);
+    return name !== "migration_lock.toml" && name !== ".DS_Store" && migrationsDir.includes(name);
   }
 
   validateMigrationName(name: string) {


### PR DESCRIPTION
- introduce --upto command (fixed the logic so that when you use this to pass a specific migration name, that migration iwll be included
- Make configuration keys optional (I think this is better so that updates to default will also be implemented for users that did not want to override the default)
- allow custom migration schema name (older configuration files should still work because all keys are now optional and fallback to the default)
- fix ".DS_STORE" typo to ".DS_Store"
- update readme to reflect above changes