### PR TITLE
Fix: updateOrAddOutputInSchema util function to properly handle cases when output in generator block is commented out

### DIFF
--- a/src/utils/updateOrAddOutputInSchema.ts
+++ b/src/utils/updateOrAddOutputInSchema.ts
@@ -1,43 +1,78 @@
 import fs from "fs";
 
-export const updateOrAddOutputInSchema = (
-  filePath: string,
-  newOutputValue: string
-) => {
+export const updateOrAddOutputInSchema = (filePath: string, newOutputValue: string) => {
   const schemaContent = fs.readFileSync(filePath, "utf-8");
 
-  const generatorRegex = /generator\s+client\s+{([^}]*)}/s;
-  const generatorBlockMatch = schemaContent.match(generatorRegex);
+  const generatorRegex = /generator\s+client\s*\{([^}]+)\}/gims;
+  const generatorMatch = schemaContent.match(generatorRegex);
 
-  if (!generatorBlockMatch) {
-    throw new Error("The generator block was not found in schema.prisma.");
+  if (!generatorMatch) {
+    throw new Error(`The generator block was not found in schema file: ${filePath}`);
   }
 
-  const generatorBlockContent = generatorBlockMatch[1];
+  const updatedSchema = schemaContent.replace(generatorRegex, (block) => {
+    let outputFound = false;
+    let inBlockComment = false;
 
-  const cleanedGeneratorBlockContent = generatorBlockContent
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0)
-    .join("\n  ");
+    const processedLines: string[] = [];
+    const lines = block.split("\n");
 
-  let updatedGeneratorBlockContent: string;
+    for (const line of lines) {
+      let currentLine = line;
+      let codePart = "";
+      let commentStart = Infinity;
 
-  if (/output\s*=\s*".*"/.test(cleanedGeneratorBlockContent)) {
-    updatedGeneratorBlockContent = cleanedGeneratorBlockContent.replace(
-      /output\s*=\s*".*"/,
-      `output = "${newOutputValue}"`
-    );
-  } else {
-    updatedGeneratorBlockContent = `${cleanedGeneratorBlockContent}\n  output = "${newOutputValue}"`;
-  }
+      if (inBlockComment) {
+        const endBlockIndex = currentLine.indexOf("*/");
+        if (endBlockIndex !== -1) {
+          inBlockComment = false;
+          currentLine = currentLine.slice(endBlockIndex + 2);
+        } else {
+          processedLines.push(line);
+          continue;
+        }
+      }
 
-  const updatedGeneratorBlock = `generator client {\n  ${updatedGeneratorBlockContent}\n}`;
+      const startBlockIndex = currentLine.indexOf("/*");
+      if (startBlockIndex !== -1) {
+        inBlockComment = true;
+        codePart = currentLine.slice(0, startBlockIndex);
+        commentStart = startBlockIndex;
+      } else {
+        codePart = currentLine;
+      }
 
-  const updatedSchema = schemaContent.replace(
-    generatorRegex,
-    updatedGeneratorBlock
-  );
+      const lineComments = [/\/\//g, /#/g].map((re) => re.exec(codePart));
+      const earliestComment = lineComments
+        .filter((match) => match)
+        .sort((a, b) => a!.index - b!.index)[0];
+
+      if (earliestComment) {
+        codePart = codePart.slice(0, earliestComment.index);
+        commentStart = Math.min(commentStart, earliestComment.index);
+      }
+
+      const outputMatch = codePart.match(/^\s*output\s*=\s*(["']).*?\1/ims);
+      if (outputMatch) {
+        outputFound = true;
+        const newLine = line.replace(
+          /(\s*output\s*=\s*["'])(.*?)(["'])/ims,
+          `$1${newOutputValue}$3`,
+        );
+        processedLines.push(newLine);
+        continue;
+      }
+
+      processedLines.push(line);
+    }
+
+    if (!outputFound) {
+      const insertPosition = processedLines.findIndex((l) => l.includes("{")) + 1;
+      processedLines.splice(insertPosition, 0, `  output = "${newOutputValue}"`);
+    }
+
+    return processedLines.join("\n");
+  });
 
   fs.writeFileSync(filePath, updatedSchema, "utf-8");
 };


### PR DESCRIPTION
This pull request includes a significant update to the `updateOrAddOutputInSchema` function within the `src/utils/updateOrAddOutputInSchema.ts` file. The changes focus on improving the regex matching and handling of the generator block, as well as refining the logic for updating or adding the output value.

Key changes include:

* **Regex Improvement**:
  - Modified the `generatorRegex` to be more robust by allowing for more flexible spacing and using global, case-insensitive, and multiline flags.

* **Error Handling**:
  - Enhanced the error message to include the specific file path when the generator block is not found.

* **Block Processing**:
  - Replaced the old method of cleaning and updating the generator block content with a more sophisticated approach that processes each line, handles block comments, and identifies the correct position to insert the new output value.

* **Output Value Update**:
  - Improved the logic to check for existing output values and replace them, or add a new output value if none is found.

* **Code Refactoring**:
  - Refactored the code to enhance readability and maintainability, ensuring that the function handles various edge cases more effectively.