### PR TITLE
Feat: Add the ability to specify a custom main `prisma.schema` file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,9 @@ The configuration file (`prisma-dm.config.json`) allows customization of the lib
   - For `.ts` scripts: `"tsx ${post}.ts"`
   - For shell scripts: `"sh ${post}.sh"`
 
-- **`outputDir`**: Directory for generated migration files.  
-  - **Default**: `../../../node_modules/prisma-data-migrations/migrations`.  
+- **`outputDir`**: Directory for generated migration files.
+
+  - **Default**: `../../../node_modules/prisma-data-migrations/migrations`.
   - **Note**: This path is specified **relative to** the `migrations/{some_migration}/schema.prisma` file, as it is the value of the `output` parameter in the Prisma schema settings block.
 
 - **`migrationsDir`**: Directory containing Prisma migrations. Default: `prisma/migrations`.
@@ -177,6 +178,8 @@ The configuration file (`prisma-dm.config.json`) allows customization of the lib
 - **`tempDir`**: Temporary directory for moving migration folders during execution. Default: `prisma/.temp`.
 
 - **`migrationSchemaFileName`**: The filename for prisma schema files within migration directories. Default: `schema.prisma`.
+
+- **`mainPrismaSchema`**: The main Prisma schema file or folder for `npx prisma migrate deploy` command. Default: `prisma/schema.prisma`.
 
 - **`log`**: Logging level (`none`, `info`, `verbose`). Default: `info`.
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -41,7 +41,7 @@
     "mainPrismaSchema": {
       "type": "string",
       "pattern": "^(\\/|\\.?\\/|\\.\\.\\/|[^\\/]+).*$",
-      "description": "The main Prisma schema file for prisma migrations. Must be a valid file path.",
+      "description": "The main Prisma schema file or folder for `npx prisma migrate deploy` command.",
       "default": "prisma/schema.prisma"
     },
     "log": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -38,23 +38,19 @@
       "description": "The filename for prisma schema files within migration directories. Defaults to schema.prisma",
       "default": "schema.prisma"
     },
+    "mainPrismaSchema": {
+      "type": "string",
+      "pattern": "^(\\/|\\.?\\/|\\.\\.\\/|[^\\/]+).*$",
+      "description": "The main Prisma schema file for prisma migrations. Must be a valid file path.",
+      "default": "prisma/schema.prisma"
+    },
     "log": {
       "type": "string",
-      "enum": [
-        "none",
-        "info",
-        "verbose"
-      ],
+      "enum": ["none", "info", "verbose"],
       "description": "Log level for the script, must be one of 'info', 'debug', or 'error'.",
       "default": "info"
     }
   },
-  "required": [
-    "execScriptCommand",
-    "outputDir",
-    "migrationsDir",
-    "tempDir",
-    "log"
-  ],
+  "required": [],
   "additionalProperties": false
 }

--- a/src/config/ConfigLoader.ts
+++ b/src/config/ConfigLoader.ts
@@ -1,13 +1,12 @@
 import path from "path";
 import fs from "fs-extra";
-import { ConfigSchema } from "./config.type";
 import { CONFIG_FILE_NAME } from "./CONFIG_FILE_NAME";
 import schema from "../../config.schema.json";
 import Ajv from "ajv";
-import { DEFAULT_CONFIG } from "./DEFAULT_CONFIG";
+import { ConfigT, DEFAULT_CONFIG } from "./DEFAULT_CONFIG";
 
 export class ConfigLoader {
-  readonly #config: ConfigSchema;
+  readonly #config: ConfigT;
 
   constructor() {
     const configFilePath = path.join(process.cwd(), CONFIG_FILE_NAME);
@@ -30,7 +29,7 @@ export class ConfigLoader {
       }
     }
 
-    const config: ConfigSchema = {
+    const config: ConfigT = {
       ...DEFAULT_CONFIG,
       ...parsedConfig,
     };

--- a/src/config/DEFAULT_CONFIG.ts
+++ b/src/config/DEFAULT_CONFIG.ts
@@ -9,9 +9,8 @@ const defaultConfig: Record<string, any> = {};
 validate(defaultConfig);
 
 if (validate.errors) {
-  throw new Error(
-    "Invalid default configuration: " + JSON.stringify(validate.errors, null, 2)
-  );
+  throw new Error("Invalid default configuration: " + JSON.stringify(validate.errors, null, 2));
 }
 
-export const DEFAULT_CONFIG = defaultConfig as ConfigSchema;
+export type ConfigT = Required<ConfigSchema>;
+export const DEFAULT_CONFIG = defaultConfig as Required<ConfigSchema>;

--- a/src/config/config.type.ts
+++ b/src/config/config.type.ts
@@ -31,7 +31,7 @@ export interface ConfigSchema {
    */
   migrationSchemaFileName?: string;
   /**
-   * The main Prisma schema file for prisma migrations. Must be a valid file path.
+   * The main Prisma schema file or folder for `npx prisma migrate deploy` command.
    */
   mainPrismaSchema?: string;
   /**

--- a/src/config/config.type.ts
+++ b/src/config/config.type.ts
@@ -13,25 +13,29 @@ export interface ConfigSchema {
   /**
    * The command to execute the script, must include the placeholder '${post}' and can have any file extension or none.
    */
-  execScriptCommand: string;
+  execScriptCommand?: string;
   /**
    * The output directory for the generated migrations. Must be a valid directory path.
    */
-  outputDir: string;
+  outputDir?: string;
   /**
    * The directory where migrations are stored. Must be a valid directory path.
    */
-  migrationsDir: string;
+  migrationsDir?: string;
   /**
    * Temporary directory for processing. Must be a valid directory path.
    */
-  tempDir: string;
+  tempDir?: string;
   /**
-   * The filename for prisma schema files within migration directories.
+   * The filename for prisma schema files within migration directories. Defaults to schema.prisma
    */
-  migrationSchemaFileName: string;
+  migrationSchemaFileName?: string;
+  /**
+   * The main Prisma schema file for prisma migrations. Must be a valid file path.
+   */
+  mainPrismaSchema?: string;
   /**
    * Log level for the script, must be one of 'info', 'debug', or 'error'.
    */
-  log: "none" | "info" | "verbose";
+  log?: "none" | "info" | "verbose";
 }

--- a/src/services/ScriptRunner.ts
+++ b/src/services/ScriptRunner.ts
@@ -1,14 +1,14 @@
 import { execSync } from "child_process";
-import { ConfigSchema } from "../config/config.type";
+import { ConfigT } from "../config/DEFAULT_CONFIG";
 import path from "path";
 
 export class ScriptRunner {
-  constructor(private readonly config: ConfigSchema) {}
+  constructor(private readonly config: ConfigT) {}
 
   runPostScript(migrationPath: string) {
     const execCommand = this.config.execScriptCommand.replace(
       "${post}",
-      path.join(migrationPath, "post")
+      path.join(migrationPath, "post"),
     );
 
     execSync(execCommand, { stdio: "inherit" });

--- a/src/services/TargetedPrismaMigrator.ts
+++ b/src/services/TargetedPrismaMigrator.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import fs from "fs-extra";
-import { ConfigSchema } from "../config/config.type";
+import { ConfigT } from "../config/DEFAULT_CONFIG";
 import { PrismaCLI } from "../utils/classes/PrismaCLI";
 import { Logger } from "./Logger";
 
@@ -9,7 +9,7 @@ type MigrationDirFile<T extends string> = T | "migration_lock.toml";
 export class TargetedPrismaMigrator<T extends string> {
   constructor(
     private readonly logger: Logger,
-    private readonly config: ConfigSchema,
+    private readonly config: ConfigT,
   ) {}
 
   private createTempDir() {
@@ -77,7 +77,7 @@ export class TargetedPrismaMigrator<T extends string> {
     await this.moveFilesToTempDir(filesToMove);
 
     try {
-      PrismaCLI.migrateDeploy();
+      PrismaCLI.migrateDeploy({ schema: this.config.mainPrismaSchema });
 
       this.logger.logVerbose(
         `All migrations to ${targetMigration} have been applied successfully!`,

--- a/src/services/Validator.ts
+++ b/src/services/Validator.ts
@@ -1,14 +1,14 @@
 import fs from "fs-extra";
 import path from "path";
-import { ConfigSchema } from "../config/config.type";
+import { ConfigT } from "../config/DEFAULT_CONFIG";
 
 export class Validator {
-  constructor(private readonly config: ConfigSchema) {}
+  constructor(private readonly config: ConfigT) {}
 
   isMigrationWithPrismaSchema(migrationName: string) {
     const migrationPath = path.join(this.config.migrationsDir, migrationName);
     const hasPrismaSchema = fs.existsSync(
-      path.join(migrationPath, this.config.migrationSchemaFileName)
+      path.join(migrationPath, this.config.migrationSchemaFileName),
     );
 
     return this.isMigration(migrationName) && hasPrismaSchema;
@@ -17,18 +17,13 @@ export class Validator {
   isMigrationWithPostScript(migrationName: string) {
     const migrationPath = path.join(this.config.migrationsDir, migrationName);
     const files = fs.readdirSync(migrationPath);
-    const hasPostScript = files.some((file) =>
-      /^post(\.[a-zA-Z0-9]+)?$/.test(file)
-    );
+    const hasPostScript = files.some((file) => /^post(\.[a-zA-Z0-9]+)?$/.test(file));
 
     return this.isMigration(migrationName) && hasPostScript;
   }
 
   isMigration(name: string) {
-    const migrationsDirPath = path.join(
-      process.cwd(),
-      this.config.migrationsDir
-    );
+    const migrationsDirPath = path.join(process.cwd(), this.config.migrationsDir);
     const migrationsDir = fs.readdirSync(migrationsDirPath);
 
     return name !== "migration_lock.toml" && name !== ".DS_Store" && migrationsDir.includes(name);

--- a/src/utils/classes/PrismaCLI.ts
+++ b/src/utils/classes/PrismaCLI.ts
@@ -8,7 +8,10 @@ export abstract class PrismaCLI {
     execSync(`${baseCommand} ${schemaFlag}`, { stdio: "ignore" });
   }
 
-  static migrateDeploy() {
-    execSync("npx prisma migrate deploy", { stdio: "inherit" });
+  static migrateDeploy({ schema }: { schema: string }) {
+    const baseCommand = "npx prisma migrate deploy";
+    const schemaFlag = `--schema=${schema}`;
+
+    execSync(`${baseCommand} ${schemaFlag}`, { stdio: "inherit" });
   }
 }


### PR DESCRIPTION
This pull request includes several changes to the configuration and schema handling within the Prisma migration tool. The most important changes include adding a new configuration option, modifying the structure of the configuration schema, and updating the TypeScript types to reflect these changes.

### Configuration and Schema Handling:

* Added a new configuration option `mainPrismaSchema` to specify the main Prisma schema file or folder for the `npx prisma migrate deploy` command. This change is reflected in the `README.md`, `config.schema.json`, and TypeScript files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R182-R183) [[2]](diffhunk://#diff-be1695b1e63a508d59982601f9e1fb7f58247deecb1e427adb77bcad758ae5e5R41-R54) [[3]](diffhunk://#diff-1f0e2748f30bbd23abe075e6f51e3bb486dd639c725e22f86317b24ee0982ceeL16-R40)

### TypeScript Type Updates:

* Updated the `ConfigSchema` type to make all properties optional and added the new `mainPrismaSchema` property. This change is reflected in the `src/config/config.type.ts` file.
* Changed the type alias `ConfigSchema` to `ConfigT` and updated all references to use the new type alias. This change affects multiple files including `src/config/ConfigLoader.ts`, `src/services/ScriptRunner.ts`, `src/services/TargetedPrismaMigrator.ts`, and `src/services/Validator.ts`. [[1]](diffhunk://#diff-d3c6cb5bfb4c84da8312432eb44a38d79e89c733c802a4d835d761c3076af6f2L3-R9) [[2]](diffhunk://#diff-e0652ced37b0fc98e2a060f03aff14b6b30f2fe1c4636ca4a9a86f1935492270L12-R16) [[3]](diffhunk://#diff-fb3d3b05db05bef5b6dae843eb95df9f780b67aed856b72456872adc88e27ee5L2-R11) [[4]](diffhunk://#diff-4b31330c20a06c47842700a4e54ad50bfa17b2f08edfcb22bce3fae0d18495a2L3-R3) [[5]](diffhunk://#diff-0a48274587473272ff7b94b21ffd577270f3bd92da65beeac6756d9e63a5a817L3-R11)

### Code Simplification and Cleanup:

* Simplified the `PrismaCLI` class by adding a `schema` parameter to the `migrateDeploy` method, allowing the schema file to be specified during migration deployment.
* Removed unnecessary required properties from the `config.schema.json` file, allowing for more flexible configuration.