### PR TITLE
Support for Prisma 7 (Breaking Changes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-data-migrations",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "dist/src/main.js",
   "types": "dist/src/main.d.ts",
   "files": [

--- a/src/services/CLI.ts
+++ b/src/services/CLI.ts
@@ -8,7 +8,7 @@ import { PrismaCLI } from "../utils/classes/PrismaCLI";
 import { createTempSchema } from "../utils/tempMigrationSchema";
 import { TargetedPrismaMigrator } from "./TargetedPrismaMigrator";
 import { ScriptRunner } from "./ScriptRunner";
-import { DataSourceConfig, DB } from "./DB";
+import { DB } from "./DB";
 import { Logger } from "./Logger";
 import { MigrationModel } from "../types/MigrationModel";
 import { withTempDir } from "../utils/tempDir";
@@ -20,9 +20,8 @@ export class CLI<T extends string> {
     private readonly db: DB,
     private readonly validator: Validator,
     private readonly logger: Logger,
-    private readonly config: ConfigSchema,
-    private readonly dataSource: DataSourceConfig,
-  ) {}
+    private readonly config: ConfigSchema
+  ) { }
 
   private getMigrationPath(migrationName: T) {
     return path.resolve(this.config.migrationsDir, migrationName);
@@ -60,9 +59,7 @@ export class CLI<T extends string> {
         await createTempSchema(
           schemaPath,
           outputPath,
-          this.dataSource,
           tempSchemaPath,
-          this.config,
         );
         PrismaCLI.generate({ schema: tempSchemaPath });
 

--- a/src/utils/readPrismaConfig.ts
+++ b/src/utils/readPrismaConfig.ts
@@ -1,0 +1,92 @@
+import path from "path";
+import { existsSync } from "fs";
+
+/**
+ * Type guard to validate Prisma config structure from defineConfig
+ */
+function isValidPrismaConfig(config: unknown): config is {
+  datasource: {
+    url: string;
+  };
+} {
+  if (!config || typeof config !== "object") {
+    return false;
+  }
+
+  if (!("datasource" in config)) {
+    return false;
+  }
+
+  const DATASOURCE = (config as { datasource?: unknown }).datasource;
+
+  if (!DATASOURCE || typeof DATASOURCE !== "object") {
+    return false;
+  }
+
+  if (!("url" in DATASOURCE)) {
+    return false;
+  }
+
+  const URL = (DATASOURCE as { url?: unknown }).url;
+
+  return typeof URL === "string";
+}
+
+/**
+ * Reads prisma.config.ts file and returns the database URL (from datasource.url).
+ * The file should be at the same level as package.json (process.cwd()).
+ * 
+ * For Prisma 7, the config file can use env("DATABASE_URL") which will be resolved to the value of process.env.DATABASE_URL during the import.
+ * 
+ * @returns The datasource URL string
+ * @throws Error if datasource URL cannot be found or is invalid
+ */
+export async function readDatabaseUrlFromPrismaConfig(): Promise<string> {
+  const CONFIG_PATH = path.join(process.cwd(), "prisma.config.ts");
+
+  // Try to parse prisma.config.ts
+  if (!existsSync(CONFIG_PATH)) {
+    throw new Error(`prisma.config.ts (at ${CONFIG_PATH}) not found`);
+  }
+
+  let prismaConfig: unknown;
+
+  try {
+    prismaConfig = await import(CONFIG_PATH);
+  } catch (importError) {
+    throw new Error(`failed to import prisma.config.ts: ${importError}`);
+  }
+
+  let CONFIG: unknown;
+
+  if (
+    typeof prismaConfig === "object" && prismaConfig !== null &&
+    "default" in prismaConfig && prismaConfig.default !== undefined
+  ) {
+    CONFIG = prismaConfig.default;
+  } else {
+    CONFIG = prismaConfig;
+  }
+
+  // Validates the config structure
+  if (!isValidPrismaConfig(CONFIG)) {
+    throw new Error(
+      `invalid prisma.config.ts structure: expected defineConfig with datasource.url property`
+    );
+  }
+
+  const DATASOURCE_URL = CONFIG.datasource.url;
+
+  if (DATASOURCE_URL.length === 0) {
+    throw new Error(`datasource.url cannot be empty in prisma.config.ts`);
+  }
+
+  // Validates the URL format
+  try {
+    new URL(DATASOURCE_URL);
+  } catch {
+    throw new Error(`invalid datasource.url format in prisma.config.ts: ${DATASOURCE_URL}`);
+  }
+
+  return DATASOURCE_URL;
+}

--- a/src/utils/tempMigrationSchema.ts
+++ b/src/utils/tempMigrationSchema.ts
@@ -64,40 +64,18 @@ function updateGenerator(ast: PrismaSchema, clientOutputPath: string): PrismaSch
 }
 
 /**
- * Updates the datasource block so that in case of SQLite,
- * the file path in the URL is absolute (not relative).
- * This is needed because the schema copied to the migrations
- * folder would have a different relative path.
- */
-function updateDatasource(
-  ast: PrismaSchema,
-  dataSource: DataSourceConfig,
-  config: ConfigSchema,
-): PrismaSchema {
-  if (dataSource.provider === "sqlite") {
-    // This ensures that the SQLite file path is absolute
-    dataSource.url = `file:${prismaSqliteURLToFilePath(dataSource.url, config)}`;
-  }
-
-  return ast;
-}
-
-/**
  * Creates a temporary Prisma schema file for generating the client for a migration.
  * The schema is based on the source schema file, but with updated generator and datasource blocks.
  */
 export async function createTempSchema(
   srcPrismaSchemaPath: string,
   clientOutputPath: string,
-  dataSource: DataSourceConfig,
-  outPrismaSchemaPath: string,
-  config: ConfigSchema,
+  outPrismaSchemaPath: string
 ) {
   const schemaContent = await fs.readFile(srcPrismaSchemaPath, "utf-8");
 
   let schemaAst = parsePrismaSchema(schemaContent);
   schemaAst = updateGenerator(schemaAst, clientOutputPath);
-  schemaAst = updateDatasource(schemaAst, dataSource, config);
 
   const formattedSchema = formatAst(schemaAst);
   await fs.mkdir(path.dirname(outPrismaSchemaPath), { recursive: true });


### PR DESCRIPTION
To enable the use of this tool with Prisma 7, this is a shady workaround. In the most recent major version of Prisma, `datasource.url` was eliminated and now generates an error if it is found in the schema file.

This PR loads the URL from `process.env.DATABASE` instead of making checks and loading it for the `datasource.url` attribute in `readDataSourceConfig`.

Additionally, it modifies the way SQLite URL is transformed from relative to absolute by updating `DataSourceConfig.url` directly rather than returning the updated AST in `updateDatasource`.
I'm not too familiar with this repo, but since `updateDatasource` is used, as I understand it, to create the intermediate `schema.prisma` in the migration folders, there's a good chance that this breaks (or at least introduces a regression) the SQLite provider and that `updateDatasource` is effectively doing nothing.
Removing the `datasource.url` from the schema.prisma and loading it using `process.env.DATABASE_URL` will only function if the URL is absolute in the first place.

I do not consider this PR clean or ready by any means, and it is just a fast way to get the tool working with the new versions of Prisma (and sharing it) because I needed it.
To properly implement this, the tool must use `prisma.config.ts`, which should be located at the user's repository root.

As soon as I have time to properly implement this, I will make the necessary changes.