### PR TITLE
Evaluate environment variables at runtime

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,14 +18,13 @@ const program = new Command();
 
 function createCLI() {
   const { config } = new ConfigLoader();
-  const dataSource = readDataSourceConfig(config.mainPrismaSchema);
 
   const logger = new Logger(config);
-  const db = new DB(config, dataSource);
+  const db = new DB();
   const validator = new Validator(config);
   const scriptRunner = new ScriptRunner(config);
   const migrator = new TargetedPrismaMigrator(logger, config);
-  const cli = new CLI(migrator, scriptRunner, db, validator, logger, config, dataSource);
+  const cli = new CLI(migrator, scriptRunner, db, validator, logger, config);
 
   return cli;
 }

--- a/src/services/CLI.ts
+++ b/src/services/CLI.ts
@@ -54,13 +54,9 @@ export class CLI<T extends string> {
         outputPath = path.join(path.dirname(schemaPath), outputPath);
       }
 
-      const tempSchemaFilename = `.tmp-migration-schema_${migrationName}.prisma`;
+      const tempSchemaFilename = `.tmp-migration-schema-${Math.random().toString(36).slice(2, 4)}_${migrationName}.prisma`;
       const tempSchemaPath = path.join(migrationsDirPath, tempSchemaFilename);
-      await createTempSchema(
-        schemaPath,
-        outputPath,
-        tempSchemaPath,
-      );
+      await createTempSchema(schemaPath, outputPath, tempSchemaPath);
       try {
         PrismaCLI.generate({ schema: tempSchemaPath });
       } finally {

--- a/src/services/CLI.ts
+++ b/src/services/CLI.ts
@@ -8,10 +8,10 @@ import { PrismaCLI } from "../utils/classes/PrismaCLI";
 import { createTempSchema } from "../utils/tempMigrationSchema";
 import { TargetedPrismaMigrator } from "./TargetedPrismaMigrator";
 import { ScriptRunner } from "./ScriptRunner";
-import { DataSourceConfig, DB } from "./DB";
+import { DB } from "./DB";
 import { Logger } from "./Logger";
 import { MigrationModel } from "../types/MigrationModel";
-import { withTempDir } from "../utils/tempDir";
+import { readDataSourceConfig } from "../utils/readDataSourceConfig";
 
 export class CLI<T extends string> {
   constructor(
@@ -21,7 +21,6 @@ export class CLI<T extends string> {
     private readonly validator: Validator,
     private readonly logger: Logger,
     private readonly config: ConfigSchema,
-    private readonly dataSource: DataSourceConfig,
   ) {}
 
   private getMigrationPath(migrationName: T) {
@@ -45,32 +44,33 @@ export class CLI<T extends string> {
       this.validator.isMigrationWithPrismaSchema(m),
     );
 
-    await withTempDir(this.config.tempDir, async () => {
-      const promises = migrationsWithSchemas.map(async (migrationName) => {
-        const migrationPath = path.join(migrationsDirPath, migrationName);
-        const schemaPath = path.join(migrationPath, this.config.migrationSchemaFileName);
-        let outputPath = `${this.config.outputDir}/${migrationName}`;
+    const promises = migrationsWithSchemas.map(async (migrationName) => {
+      const migrationPath = path.join(migrationsDirPath, migrationName);
+      const schemaPath = path.join(migrationPath, this.config.migrationSchemaFileName);
+      let outputPath = `${this.config.outputDir}/${migrationName}`;
 
-        // If the path is relative, it is relative to the schema file inside the migration folder
-        if (!path.isAbsolute(outputPath)) {
-          outputPath = path.join(path.dirname(schemaPath), outputPath);
-        }
+      // If the path is relative, it is relative to the schema file inside the migration folder
+      if (!path.isAbsolute(outputPath)) {
+        outputPath = path.join(path.dirname(schemaPath), outputPath);
+      }
 
-        const tempSchemaPath = path.join(this.config.tempDir, migrationName, "schema.prisma");
-        await createTempSchema(
-          schemaPath,
-          outputPath,
-          this.dataSource,
-          tempSchemaPath,
-          this.config,
-        );
+      const tempSchemaFilename = `.tmp-migration-schema_${migrationName}.prisma`;
+      const tempSchemaPath = path.join(migrationsDirPath, tempSchemaFilename);
+      await createTempSchema(
+        schemaPath,
+        outputPath,
+        tempSchemaPath,
+      );
+      try {
         PrismaCLI.generate({ schema: tempSchemaPath });
+      } finally {
+        fs.rmSync(tempSchemaPath);
+      }
 
-        this.logger.logInfo(`Types generated for migration: ${migrationName}`);
-      });
-
-      await Promise.all(promises);
+      this.logger.logInfo(`Types generated for migration: ${migrationName}`);
     });
+
+    await Promise.all(promises);
 
     this.logger.logInfo("Types generation completed");
   }
@@ -133,7 +133,9 @@ export class CLI<T extends string> {
       lastMigrationIndex + (includeTargetMigration ? 1 : 0),
     );
     const dataMigrations = migrations.filter((m) => this.validator.isMigrationWithPostScript(m));
-    await this.db.connect();
+
+    const dataSource = readDataSourceConfig(this.config.mainPrismaSchema);
+    await this.db.connect(dataSource, this.config);
 
     for (const migrationName of dataMigrations as T[]) {
       const prismaTableExists = await this.db.isPrismaMigrationsTableExists();

--- a/src/services/DB.ts
+++ b/src/services/DB.ts
@@ -43,15 +43,11 @@ function createKnexConfig(dataSource: DataSourceConfig, config: ConfigSchema): K
 }
 
 export class DB {
-  private readonly knexConfig: Knex.Config;
   private knex?: Knex;
 
-  constructor(config: ConfigSchema, dataSource: DataSourceConfig) {
-    this.knexConfig = createKnexConfig(dataSource, config);
-  }
-
-  async connect() {
-    this.knex = knex(this.knexConfig);
+  async connect(datasource: DataSourceConfig, config: ConfigSchema) {
+    const knexConfig = createKnexConfig(datasource, config);
+    this.knex = knex(knexConfig);
   }
 
   async disconnect() {


### PR DESCRIPTION
This PR fixes the issue that environment variables inside the Prisma schema file are evaluated at generation time, not at runtime. This might be problematic in some cases, such as generating during the build of a Docker image, but setting environment variables only when deploying the container. The issue is mentioned in [this comment](https://github.com/Softjey/prisma-dm/pull/18#issuecomment-3418725977) in #18.

The main problem to solve was that environment variables can contain relative paths, and these must be resolved relative to the main prisma file. Prisma handles this by storing the path of the prisma file in the generated client, so that it can correctly resolve the relative paths. The solution that I offer in this PR is that instead of creating temporary Prisma schemas in the temp directory during generation (which would cause relative paths to be resolved relative to the temp directory), they are created directly alongside the main Prisma file, and then immediately deleted. This ensures that the relative paths are resolved correctly.

## Included Changes

- The `generate` method in `CLI.ts` is changed to create the temporary schemas alongside the main schema
- The `updateDatasource` method that did the rewriting of variables at build time is removed
- Moved database initialization from the constructor to a dedicated `connect` method (which is only called when the database is actually needed); this makes sure that functionalities that do not depend on the database (like generation) still work even if the database or values of environment variables are not available (as might be the case in a Docker image builder)

## Notes

I have tested that the changes work as expected when using SQLite **in my use case**, but I have **not** exhausted all possible configuration options of this library nor of Prisma. Therefore, I am hesitant to mark it as "Tested & 100% working", as that is a very strong statement and might change at any time with new updates. If you change the wording to something less strong (like just "Tested"), I will be happy to mark that.