### PR TITLE
Support "prisma-client" (for Prisma v7)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,6 @@ import { ScriptRunner } from "./services/ScriptRunner";
 import { TargetedPrismaMigrator } from "./services/TargetedPrismaMigrator";
 import { Validator } from "./services/Validator";
 import { Command } from "commander";
-import { readDataSourceConfig } from "./utils/readDataSourceConfig";
 import packageJson from "../package.json";
 import dotenv from "dotenv";
 

--- a/src/services/CLI.ts
+++ b/src/services/CLI.ts
@@ -130,7 +130,7 @@ export class CLI<T extends string> {
     );
     const dataMigrations = migrations.filter((m) => this.validator.isMigrationWithPostScript(m));
 
-    const dataSource = readDataSourceConfig(this.config.mainPrismaSchema);
+    const dataSource = await readDataSourceConfig(this.config.mainPrismaSchema);
     await this.db.connect(dataSource, this.config);
 
     for (const migrationName of dataMigrations as T[]) {

--- a/src/utils/readPrismaConfig.ts
+++ b/src/utils/readPrismaConfig.ts
@@ -1,0 +1,92 @@
+import path from "path";
+import { existsSync } from "fs";
+
+/**
+ * Type guard to validate Prisma config structure from defineConfig
+ */
+function isValidPrismaConfig(config: unknown): config is {
+  datasource: {
+    url: string;
+  };
+} {
+  if (!config || typeof config !== "object") {
+    return false;
+  }
+
+  if (!("datasource" in config)) {
+    return false;
+  }
+
+  const DATASOURCE = (config as { datasource?: unknown }).datasource;
+
+  if (!DATASOURCE || typeof DATASOURCE !== "object") {
+    return false;
+  }
+
+  if (!("url" in DATASOURCE)) {
+    return false;
+  }
+
+  const URL = (DATASOURCE as { url?: unknown }).url;
+
+  return typeof URL === "string";
+}
+
+/**
+ * Reads prisma.config.ts file and returns the database URL (from datasource.url).
+ * The file should be at the same level as package.json (process.cwd()).
+ * 
+ * For Prisma 7, the config file can use env("DATABASE_URL") which will be resolved to the value of process.env.DATABASE_URL during the import.
+ * 
+ * @returns The datasource URL string
+ * @throws Error if datasource URL cannot be found or is invalid
+ */
+export async function readDatabaseUrlFromPrismaConfig(): Promise<string> {
+  const CONFIG_PATH = path.join(process.cwd(), "prisma.config.ts");
+
+  // Try to parse prisma.config.ts
+  if (!existsSync(CONFIG_PATH)) {
+    throw new Error(`prisma.config.ts (at ${CONFIG_PATH}) not found`);
+  }
+
+  let prismaConfig: unknown;
+
+  try {
+    prismaConfig = await import(CONFIG_PATH);
+  } catch (importError) {
+    throw new Error(`failed to import prisma.config.ts: ${importError}`);
+  }
+
+  let CONFIG: unknown;
+
+  if (
+    typeof prismaConfig === "object" && prismaConfig !== null &&
+    "default" in prismaConfig && prismaConfig.default !== undefined
+  ) {
+    CONFIG = prismaConfig.default;
+  } else {
+    CONFIG = prismaConfig;
+  }
+
+  // Validates the config structure
+  if (!isValidPrismaConfig(CONFIG)) {
+    throw new Error(
+      `invalid prisma.config.ts structure: expected defineConfig with datasource.url property`
+    );
+  }
+
+  const DATASOURCE_URL = CONFIG.datasource.url;
+
+  if (DATASOURCE_URL.length === 0) {
+    throw new Error(`datasource.url cannot be empty in prisma.config.ts`);
+  }
+
+  // Validates the URL format
+  try {
+    new URL(DATASOURCE_URL);
+  } catch {
+    throw new Error(`invalid datasource.url format in prisma.config.ts: ${DATASOURCE_URL}`);
+  }
+
+  return DATASOURCE_URL;
+}

--- a/src/utils/tempMigrationSchema.ts
+++ b/src/utils/tempMigrationSchema.ts
@@ -22,7 +22,7 @@ function isClientGenerator(decl: SchemaDeclaration): boolean {
         member.kind === "config" &&
         member.name.value === "provider" &&
         member.value.kind === "literal" &&
-        member.value.value === "prisma-client-js",
+        (member.value.value === "prisma-client-js" || member.value.value === "prisma-client"),
     )
   );
 }
@@ -35,7 +35,7 @@ function updateGenerator(ast: PrismaSchema, clientOutputPath: string): PrismaSch
   const astCopy = structuredClone(ast);
   const clientGenerators = astCopy.declarations.filter((decl) => isClientGenerator(decl));
   if (clientGenerators.length !== 1) {
-    throw new Error("The schema must contain exactly one generator block for prisma-client-js.");
+    throw new Error("The schema must contain exactly one generator block for prisma-client-js or prisma-client.");
   }
 
   let generator = clientGenerators[0];

--- a/src/utils/tempMigrationSchema.ts
+++ b/src/utils/tempMigrationSchema.ts
@@ -7,11 +7,7 @@ import {
   Config,
   formatAst,
   CommentBlock,
-  ConfigBlockMember,
 } from "@loancrate/prisma-schema-parser";
-import { DataSourceConfig } from "../services/DB";
-import { prismaSqliteURLToFilePath } from "./prismaSqliteURLToFilePath";
-import { ConfigSchema } from "../config/config.type";
 import path from "path";
 
 function isClientGenerator(decl: SchemaDeclaration): boolean {


### PR DESCRIPTION
Thanks to the work in #23, supporting Prisma v7 is easy.

In addition to the proposed trivial change, I updated my copied schemas like this with the same boilerplate as my live schema:
```prisma
generator client {
  provider = "prisma-client"
  output   = "../src/generated/prisma"
}

datasource db {
  provider = "postgresql"
}
```

Then `npx prisma-dm generate` worked. Then in `post.ts`, I have:
```ts
import { PrismaPg } from '@prisma/adapter-pg'
import { PrismaClient } from 'prisma-data-migrations/migrations/20260101120000_xyz/client'
...
const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL as string });
const prisma = new PrismaClient({ adapter });
```

And that's all I needed to do.